### PR TITLE
Edit main and detail screen

### DIFF
--- a/bilrun/lib/screens/lend/lend_controller.dart
+++ b/bilrun/lib/screens/lend/lend_controller.dart
@@ -1,3 +1,4 @@
+import 'package:bilrun/screens/main/main_screen.dart';
 import 'package:get/get.dart';
 import 'package:bilrun/screens/lend/lend_service.dart';
 import 'package:bilrun/model/product_list_model.dart';
@@ -12,7 +13,7 @@ class LendProductController extends GetxController {
 
   @override
   void onInit() {
-    userToken = Get.arguments;
+    userToken = MainScreenState.mainUserToken;
     fetchProducts();
     super.onInit();
     print("onit 실행됨");

--- a/bilrun/lib/screens/lend/lend_main.dart
+++ b/bilrun/lib/screens/lend/lend_main.dart
@@ -27,21 +27,20 @@ class _LendMainState extends State<LendMain> {
   // static String fullLocation;
   static String UserToken;
 
-  @override
-  void initState() {
-    super.initState();
-    UserToken = Get.arguments;
-  }
-
   LendProductController productController = Get.put(LendProductController());
 
   Future<Null> refresh() async {
-    UserToken = Get.arguments;
-    print("lend에서 useToken : $UserToken");
+    // print("lend에서 useToken : $UserToken");
     ProductListService.fetchLendProducts(UserToken);
     // LendProductController.fetchProducts();
 
     this.productController = Get.put(LendProductController());
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    UserToken = Get.arguments;
   }
 
   @override
@@ -90,7 +89,7 @@ class _LendMainState extends State<LendMain> {
           //                 size: 25,
           //               ),
           //               onPressed: () {
-          //                 Get.to(SetLocation());
+          //                 Get.to(()=>SetLocation());
           //               })
           //         ],
           //       );

--- a/bilrun/lib/screens/lend/lend_main.dart
+++ b/bilrun/lib/screens/lend/lend_main.dart
@@ -1,3 +1,4 @@
+import 'package:bilrun/screens/main/main_screen.dart';
 import 'package:bilrun/widgets/community/now_community.dart';
 import 'package:bilrun/widgets/notice/notice_banner.dart';
 import 'package:bilrun/widgets/notice/notice_controller.dart';
@@ -25,7 +26,7 @@ List<String> noticeImgList = [];
 class _LendMainState extends State<LendMain> {
   bool isTaped = false;
   // static String fullLocation;
-  static String UserToken;
+  static String UserToken = MainScreenState.mainUserToken;
 
   LendProductController productController = Get.put(LendProductController());
 
@@ -35,12 +36,6 @@ class _LendMainState extends State<LendMain> {
     // LendProductController.fetchProducts();
 
     this.productController = Get.put(LendProductController());
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    UserToken = Get.arguments;
   }
 
   @override
@@ -229,5 +224,3 @@ class _LendMainState extends State<LendMain> {
     );
   }
 }
-
-// bool _isPressed = false;

--- a/bilrun/lib/screens/lend/lend_product_list.dart
+++ b/bilrun/lib/screens/lend/lend_product_list.dart
@@ -39,7 +39,8 @@ class LendProductTile extends StatelessWidget {
         children: <Widget>[
           GestureDetector(
             onTap: () => {
-              Get.to(DetailScreen(), arguments: [lendproduct.id, userToken])
+              Get.to(() => DetailScreen(),
+                  arguments: [lendproduct.id, userToken])
             },
             child: Stack(
               children: [

--- a/bilrun/lib/screens/main/main_screen.dart
+++ b/bilrun/lib/screens/main/main_screen.dart
@@ -14,20 +14,23 @@ void main() async {
 class MainScreen extends StatefulWidget {
   MainScreen({Key key, this.title}) : super(key: key);
   final String title;
+
   @override
-  _MainScreenState createState() => _MainScreenState();
+  MainScreenState createState() => MainScreenState();
 }
 
-class _MainScreenState extends State<MainScreen> {
+class MainScreenState extends State<MainScreen> {
+  static String mainUserToken = Get.arguments;
+
   int currentIndex = 0;
   int passIndex = 0;
   // ignore: unused_field
   int _counter = 0;
 
-  final List<Widget> _pages = [
+  final List<dynamic> _pages = [
     LendMain(),
     RentMain(),
-    //DialogProductRegister(),
+    DialogProductRegister(),
     ChatScreen(),
     MyPageScreen(),
   ];
@@ -43,13 +46,6 @@ class _MainScreenState extends State<MainScreen> {
     setState(() {
       _counter++;
     });
-  }
-
-  static String userToken;
-  @override
-  void initState() {
-    super.initState();
-    userToken = Get.arguments;
   }
 
   @override
@@ -93,19 +89,7 @@ class _MainScreenState extends State<MainScreen> {
                 label: '빌림',
               ),
               BottomNavigationBarItem(
-                icon: IconButton(
-                  padding: EdgeInsets.zero,
-                  icon: Icon(Icons.add_box_rounded),
-                  iconSize: 22,
-                  onPressed: () {
-                    // showCupertinoModalBottomSheet(
-                    //   expand: false,
-                    //   context: context,
-                    //   builder: (context) => DialogProductRegister(),
-                    // );
-                    Get.dialog(DialogProductRegister(), arguments: userToken);
-                  },
-                ),
+                icon: Icon(Icons.add_box_rounded),
                 label: '상품 등록',
               ),
               BottomNavigationBarItem(

--- a/bilrun/lib/screens/main/main_screen.dart
+++ b/bilrun/lib/screens/main/main_screen.dart
@@ -1,3 +1,4 @@
+import 'package:bilrun/design/usedColors.dart';
 import 'package:bilrun/screens/chat/chat_list/chat_list_screen.dart';
 import 'package:bilrun/screens/lend/lend_main.dart';
 import 'package:bilrun/screens/mypage/mypage_screen.dart';
@@ -10,32 +11,23 @@ void main() async {
   runApp(MainScreen());
 }
 
-class MainScreen extends StatelessWidget {
-  const MainScreen({Key key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Material(child: MainScreenPage(title: '빌려주러 달려 가는 중 ! - 빌RUN'));
-  }
-}
-
-class MainScreenPage extends StatefulWidget {
-  MainScreenPage({Key key, this.title}) : super(key: key);
+class MainScreen extends StatefulWidget {
+  MainScreen({Key key, this.title}) : super(key: key);
   final String title;
   @override
-  _MainScreenPageState createState() => _MainScreenPageState();
+  _MainScreenState createState() => _MainScreenState();
 }
 
-class _MainScreenPageState extends State<MainScreenPage> {
+class _MainScreenState extends State<MainScreen> {
   int currentIndex = 0;
   int passIndex = 0;
   // ignore: unused_field
   int _counter = 0;
 
-  final List<Widget> _children = [
+  final List<Widget> _pages = [
     LendMain(),
     RentMain(),
-    DialogProductRegister(),
+    //DialogProductRegister(),
     ChatScreen(),
     MyPageScreen(),
   ];
@@ -62,72 +54,74 @@ class _MainScreenPageState extends State<MainScreenPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: _children[currentIndex],
-      bottomNavigationBar: BottomNavigationBar(
-          unselectedItemColor: Color(0xff999999),
-          selectedItemColor: Color(0xffaa0000),
-          type: BottomNavigationBarType.fixed,
-          onTap: _onTap,
-          currentIndex: currentIndex,
-          items: [
-            BottomNavigationBarItem(
-              icon: currentIndex == 0
-                  ? Image.asset(
-                      'assets/images/lendlogored.png',
-                      width: 22,
-                      height: 22,
-                    )
-                  : Image.asset(
-                      'assets/images/lendlogo.png',
-                      width: 22,
-                      height: 22,
-                    ),
-              label: '빌려드림',
-            ),
-            BottomNavigationBarItem(
-              icon: currentIndex == 1
-                  ? Image.asset(
-                      'assets/images/rentlogored.png',
-                      width: 22,
-                      height: 22,
-                    )
-                  : Image.asset(
-                      'assets/images/rentlogo.png',
-                      width: 22,
-                      height: 22,
-                    ),
-              label: '빌림',
-            ),
-            BottomNavigationBarItem(
-              icon: IconButton(
-                padding: EdgeInsets.zero,
-                icon: Icon(Icons.add_box_rounded),
-                iconSize: 22,
-                onPressed: () {
-                  // showCupertinoModalBottomSheet(
-                  //   expand: false,
-                  //   context: context,
-                  //   builder: (context) => DialogProductRegister(),
-                  // );
-                  Get.dialog(DialogProductRegister(), arguments: userToken);
-                },
+    return MaterialApp(
+      home: Scaffold(
+        body: _pages[currentIndex],
+        bottomNavigationBar: BottomNavigationBar(
+            unselectedItemColor: mainGrey,
+            selectedItemColor: mainRed,
+            type: BottomNavigationBarType.fixed,
+            onTap: _onTap,
+            currentIndex: currentIndex,
+            items: [
+              BottomNavigationBarItem(
+                icon: currentIndex == 0
+                    ? Image.asset(
+                        'assets/images/lendlogored.png',
+                        width: 22,
+                        height: 22,
+                      )
+                    : Image.asset(
+                        'assets/images/lendlogo.png',
+                        width: 22,
+                        height: 22,
+                      ),
+                label: '빌려드림',
               ),
-              label: '상품 등록',
-            ),
-            BottomNavigationBarItem(
-              icon: Image.asset(
-                'assets/images/chatlogo.png',
-                width: 22,
-                height: 22,
+              BottomNavigationBarItem(
+                icon: currentIndex == 1
+                    ? Image.asset(
+                        'assets/images/rentlogored.png',
+                        width: 22,
+                        height: 22,
+                      )
+                    : Image.asset(
+                        'assets/images/rentlogo.png',
+                        width: 22,
+                        height: 22,
+                      ),
+                label: '빌림',
               ),
-              label: '채팅',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.person),
-              label: '마이페이지',
-            ),
-          ]),
+              BottomNavigationBarItem(
+                icon: IconButton(
+                  padding: EdgeInsets.zero,
+                  icon: Icon(Icons.add_box_rounded),
+                  iconSize: 22,
+                  onPressed: () {
+                    // showCupertinoModalBottomSheet(
+                    //   expand: false,
+                    //   context: context,
+                    //   builder: (context) => DialogProductRegister(),
+                    // );
+                    Get.dialog(DialogProductRegister(), arguments: userToken);
+                  },
+                ),
+                label: '상품 등록',
+              ),
+              BottomNavigationBarItem(
+                icon: Image.asset(
+                  'assets/images/chatlogo.png',
+                  width: 22,
+                  height: 22,
+                ),
+                label: '채팅',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.person),
+                label: '마이페이지',
+              ),
+            ]),
+      ),
     );
   }
 }

--- a/bilrun/lib/screens/mypage/mypage_screen.dart
+++ b/bilrun/lib/screens/mypage/mypage_screen.dart
@@ -106,7 +106,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
                             child: IconButton(
                                 icon: Icon(Icons.arrow_forward_ios),
                                 onPressed: () {
-                                  Get.to(ProfileDetailScreen());
+                                  Get.to(() => ProfileDetailScreen());
                                 }),
                           ),
                         ],
@@ -186,7 +186,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
                                         children: <Widget>[
                                           IconButton(
                                             onPressed: () {
-                                              Get.to(DealManagement());
+                                              Get.to(() => DealManagement());
                                             },
                                             icon: Image.asset(
                                               'assets/images/dealListButton.png',

--- a/bilrun/lib/screens/mypage/profile/product_review_services/product_review_controller.dart
+++ b/bilrun/lib/screens/mypage/profile/product_review_services/product_review_controller.dart
@@ -1,4 +1,5 @@
 import 'package:bilrun/model/product_review_model.dart';
+import 'package:bilrun/screens/main/main_screen.dart';
 
 import 'package:get/get.dart';
 import 'product_review_service.dart';
@@ -12,7 +13,7 @@ class ProductReviewListController extends GetxController {
 
   @override
   void onInit() {
-    userToken = Get.arguments;
+    userToken = MainScreenState.mainUserToken;
     ReviewFetchList();
     super.onInit();
     print('물품리뷰리스트 실행');

--- a/bilrun/lib/screens/mypage/profile/user_review_services/review_controller.dart
+++ b/bilrun/lib/screens/mypage/profile/user_review_services/review_controller.dart
@@ -1,4 +1,5 @@
 import 'package:bilrun/model/user_review_model.dart';
+import 'package:bilrun/screens/main/main_screen.dart';
 import 'package:get/get.dart';
 import 'review_service.dart';
 
@@ -11,7 +12,7 @@ class ReviewListController extends GetxController {
 
   @override
   void onInit() {
-    userToken = Get.arguments;
+    userToken = MainScreenState.mainUserToken;
     ReviewFetchList();
     super.onInit();
     // print('리뷰리스트 실행');

--- a/bilrun/lib/screens/product_detail/another_user_product_list/etc_controller.dart
+++ b/bilrun/lib/screens/product_detail/another_user_product_list/etc_controller.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:bilrun/screens/product_detail/service/product_detail_service.dart';
 import 'package:get/state_manager.dart';
 import 'etc_service.dart';
 import 'package:bilrun/model/product_list_model.dart';
@@ -13,25 +13,14 @@ class EtcProductController extends GetxController {
   static Future fetchEtcProducts(userId) async {
     try {
       isLoading(true);
-      var products = await EtcProductService.fetchEtcProducts(userId);
+      var products = await EtcProductService.fetchEtcProducts(
+          userId, DetailProductService.userToken);
 
       if (products != null) {
         productList.value = products;
       } else if (products == null) {
-        print('error');
-        return Scaffold(
-          body: Column(
-            children: [Text('데이터 로드 실패')],
-          ),
-        );
-      } else {
-        return Scaffold(
-          body: Column(
-            children: [
-              Text('인터넷 연결을 확인해주세요.'),
-            ],
-          ),
-        );
+        print('etc controller error');
+        return null;
       }
     } finally {
       isLoading(false);

--- a/bilrun/lib/screens/product_detail/another_user_product_list/etc_list.dart
+++ b/bilrun/lib/screens/product_detail/another_user_product_list/etc_list.dart
@@ -7,7 +7,8 @@ import 'package:bilrun/screens/product_detail/product_detail_main.dart';
 class EtcProductTile extends StatelessWidget {
   final ProductList lendproduct;
   final int UserId;
-  const EtcProductTile(this.lendproduct, this.UserId);
+  final String UserToken;
+  const EtcProductTile(this.lendproduct, this.UserId, this.UserToken);
 
   @override
   Widget build(BuildContext context) {
@@ -38,10 +39,9 @@ class EtcProductTile extends StatelessWidget {
         children: <Widget>[
           GestureDetector(
             onTap: () => {
-              Get.to(
-                DetailScreen(),
-                arguments: lendproduct,
-              )
+              Get.off(() => DetailScreen(),
+                  arguments: [lendproduct.id, UserToken]),
+              print("tap!!")
             },
             child: Stack(
               children: [

--- a/bilrun/lib/screens/product_detail/another_user_product_list/etc_service.dart
+++ b/bilrun/lib/screens/product_detail/another_user_product_list/etc_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'package:bilrun/widgets/etc.dart';
 
 import 'package:http/http.dart' as http;
@@ -6,16 +7,21 @@ import 'package:bilrun/model/product_list_model.dart';
 
 class EtcProductService {
   static var client = http.Client();
+  static bool result;
 
-  static Future<List<ProductList>> fetchEtcProducts(int userId) async {
+  static Future<List<ProductList>> fetchEtcProducts(
+      int userId, var userToken) async {
     var response = await client.get(
-        Uri.parse('$serviceUrl/lend_product_list/user_id=$userId?format=json'));
+        Uri.parse('$serviceUrl/lend_product_list/user_id=$userId?format=json'),
+        headers: {HttpHeaders.authorizationHeader: "jwt $userToken"});
 
     if (response.statusCode == 200) {
       String jsonString = utf8.decode(response.bodyBytes);
+      result = true;
 
       return productListFromJson(jsonString);
     } else {
+      result = false;
       return null;
     }
   }

--- a/bilrun/lib/screens/product_detail/detail_body.dart
+++ b/bilrun/lib/screens/product_detail/detail_body.dart
@@ -1,6 +1,7 @@
 import 'package:bilrun/design/usedColors.dart';
 import 'package:bilrun/screens/product_detail/another_user_product_list/etc_controller.dart';
 import 'package:bilrun/screens/product_detail/another_user_product_list/etc_list.dart';
+import 'package:bilrun/screens/product_detail/service/product_detail_service.dart';
 
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -261,8 +262,8 @@ class DetailScreenBody extends StatelessWidget {
                               EtcProductController.productList.length, (index) {
                             return EtcProductTile(
                                 EtcProductController.productList[index],
-                                EtcProductController
-                                    .productList[index].user.id);
+                                EtcProductController.productList[index].user.id,
+                                DetailProductService.userToken);
                           }),
                         );
                     }),

--- a/bilrun/lib/screens/product_detail/product_detail_main.dart
+++ b/bilrun/lib/screens/product_detail/product_detail_main.dart
@@ -238,7 +238,7 @@ class _DetailScreenState extends State<DetailScreen> {
             }
             if (dpController.lend == false) {
               if (dpController.photo1.isEmpty) {
-                return null;
+                productImgList.clear();
               } else {
                 productImgList
                     .add(DetailProductController.productList.value.photo1);
@@ -261,14 +261,6 @@ class _DetailScreenState extends State<DetailScreen> {
               }
             }
 
-            productImgList
-                .add(DetailProductController.productList.value.photo3);
-            productImgList
-                .add(DetailProductController.productList.value.photo4);
-            productImgList
-                .add(DetailProductController.productList.value.photo5);
-
-            print(productImgList);
             return DetailBanner();
           }
         });

--- a/bilrun/lib/screens/product_detail/service/product_detail_service.dart
+++ b/bilrun/lib/screens/product_detail/service/product_detail_service.dart
@@ -8,11 +8,10 @@ import 'package:bilrun/model/product_detail_model.dart';
 
 class DetailProductService {
   static var client = http.Client();
+  static var productID = Get.arguments[0];
+  static var userToken = Get.arguments[1];
 
   static Future<DetailProduct> fetchLendDetailInfo() async {
-    var productID = Get.arguments[0];
-    var userToken = Get.arguments[1];
-
     var response;
 
     // var IdOfProduct=1;

--- a/bilrun/lib/screens/product_detail/service/product_detail_service.dart
+++ b/bilrun/lib/screens/product_detail/service/product_detail_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'package:bilrun/screens/main/main_screen.dart';
 import 'package:bilrun/widgets/etc.dart';
 import 'package:http/http.dart' as http;
 import 'package:get/state_manager.dart';
@@ -9,7 +10,7 @@ import 'package:bilrun/model/product_detail_model.dart';
 class DetailProductService {
   static var client = http.Client();
   static var productID = Get.arguments[0];
-  static var userToken = Get.arguments[1];
+  static var userToken = MainScreenState.mainUserToken;
 
   static Future<DetailProduct> fetchLendDetailInfo() async {
     var response;

--- a/bilrun/lib/screens/product_register/register_popup.dart
+++ b/bilrun/lib/screens/product_register/register_popup.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 import 'package:bilrun/design/divider_example.dart';
 import 'package:bilrun/design/usedColors.dart';
+import 'package:bilrun/screens/main/main_screen.dart';
 import 'package:bilrun/screens/product_register/register_screen.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -17,7 +18,7 @@ class _DialogProductRegisterState extends State<DialogProductRegister> {
   @override
   void initState() {
     super.initState();
-    userToken = Get.arguments;
+    userToken = MainScreenState.mainUserToken;
   }
 
   @override

--- a/bilrun/lib/screens/product_register/register_popup.dart
+++ b/bilrun/lib/screens/product_register/register_popup.dart
@@ -58,7 +58,7 @@ class _DialogProductRegisterState extends State<DialogProductRegister> {
                     child: Center(
                       child: TextButton(
                         onPressed: () => {
-                          Get.to(ProductRegister(),
+                          Get.to(() => ProductRegister(),
                               arguments: [true, userToken])
                         },
                         child: Text("빌려드림",
@@ -83,7 +83,7 @@ class _DialogProductRegisterState extends State<DialogProductRegister> {
                     child: Center(
                       child: TextButton(
                         onPressed: () => {
-                          Get.to(ProductRegister(),
+                          Get.to(() => ProductRegister(),
                               arguments: [false, userToken])
                         },
                         child: Text("빌림",

--- a/bilrun/lib/screens/product_register/register_screen.dart
+++ b/bilrun/lib/screens/product_register/register_screen.dart
@@ -1,16 +1,14 @@
 import 'dart:core';
 import 'dart:io';
-
 import 'package:bilrun/design/usedColors.dart';
+import 'package:bilrun/screens/main/main_screen.dart';
 import 'package:bilrun/screens/product_register/register_components.dart';
 import 'package:bilrun/screens/product_register/register_service/product_register_service.dart';
 import 'package:bilrun/widgets/location/set_location.dart';
-
 import 'package:bilrun/widgets/pick_up_photos.dart';
 import 'package:bilrun/widgets/white_appbar.dart';
 import 'package:flutter/material.dart';
 import 'package:bilrun/design/divider_example.dart';
-
 import 'package:get/get.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
@@ -59,7 +57,7 @@ class ProductRegisterWidgetState extends State<ProductRegisterWidget> {
   void initState() {
     super.initState();
     ProductCategory = Get.arguments[0];
-    userToken = Get.arguments[1];
+    userToken = MainScreenState.mainUserToken;
     isSelected = [true, false, false];
   }
 

--- a/bilrun/lib/screens/rent/rent_controller.dart
+++ b/bilrun/lib/screens/rent/rent_controller.dart
@@ -7,10 +7,10 @@ class RentProductController extends GetxController {
   static var isLoading = true.obs;
   // ignore: deprecated_member_use
   static var rentProductList = List<ProductList>().obs;
-  static String userToken;
+  static String userToken = Get.arguments;
+
   @override
   void onInit() {
-    userToken = Get.arguments;
     rentfetchProducts();
     super.onInit();
   }

--- a/bilrun/lib/screens/rent/rent_controller.dart
+++ b/bilrun/lib/screens/rent/rent_controller.dart
@@ -1,3 +1,4 @@
+import 'package:bilrun/screens/main/main_screen.dart';
 import 'package:bilrun/screens/rent/rent_service.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -7,15 +8,16 @@ class RentProductController extends GetxController {
   static var isLoading = true.obs;
   // ignore: deprecated_member_use
   static var rentProductList = List<ProductList>().obs;
-  static String userToken = Get.arguments;
+  static String userToken;
 
   @override
   void onInit() {
-    rentfetchProducts();
+    userToken = MainScreenState.mainUserToken;
+    rentfetchProducts(userToken);
     super.onInit();
   }
 
-  static Future rentfetchProducts() async {
+  static Future rentfetchProducts(String userToken) async {
     try {
       isLoading(true);
       var rentProducts =

--- a/bilrun/lib/screens/rent/rent_main.dart
+++ b/bilrun/lib/screens/rent/rent_main.dart
@@ -1,5 +1,6 @@
 import 'package:bilrun/design/divider_example.dart';
 import 'package:bilrun/design/usedColors.dart';
+import 'package:bilrun/screens/main/main_screen.dart';
 import 'package:bilrun/screens/rent/rent_controller.dart';
 import 'package:bilrun/screens/rent/rent_product_list.dart';
 import 'package:bilrun/screens/rent/rent_service.dart';
@@ -21,13 +22,13 @@ class RentMain extends StatefulWidget {
 }
 
 class _RentMainState extends State<RentMain> {
-  static String UserToken = RentProductController.userToken;
+  static String UserToken = MainScreenState.mainUserToken;
   RentProductController rentProductController =
       Get.put(RentProductController());
 
   Future<Null> refresh() async {
     RentProductListService.fetchRentProducts(UserToken);
-    RentProductController.rentfetchProducts();
+    RentProductController.rentfetchProducts(UserToken);
     rentProductController = Get.put(RentProductController());
   }
 

--- a/bilrun/lib/screens/rent/rent_main.dart
+++ b/bilrun/lib/screens/rent/rent_main.dart
@@ -21,7 +21,7 @@ class RentMain extends StatefulWidget {
 }
 
 class _RentMainState extends State<RentMain> {
-  static String UserToken;
+  static String UserToken = RentProductController.userToken;
   RentProductController rentProductController =
       Get.put(RentProductController());
 
@@ -31,15 +31,11 @@ class _RentMainState extends State<RentMain> {
     rentProductController = Get.put(RentProductController());
   }
 
-  @override
-  void initState() {
-    super.initState();
-  }
-
   static String fullLocation;
 
   @override
   Widget build(BuildContext context) {
+    print("rent main token : $UserToken");
     return Scaffold(
       appBar: PreferredSize(
         preferredSize: Size.fromHeight(52),

--- a/bilrun/lib/screens/rent/rent_product_list.dart
+++ b/bilrun/lib/screens/rent/rent_product_list.dart
@@ -10,6 +10,7 @@ class RentProductTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print("rent token :: $userToken");
     int differenceDay = int.parse(
         DateTime.now().difference(product.createdAt).inDays.toString());
     int differenceHours = int.parse(
@@ -37,6 +38,10 @@ class RentProductTile extends StatelessWidget {
                 width: Get.width * 0.867,
                 height: Get.height * 0.081,
                 child: ListTile(
+                  onTap: () => {
+                    Get.to(() => DetailScreen(),
+                        arguments: [product.id, userToken])
+                  },
                   title: Container(
                     width: 246,
                     height: 22,
@@ -110,9 +115,6 @@ class RentProductTile extends StatelessWidget {
                       ),
                     ],
                   ),
-                  onTap: () => {
-                    Get.to(DetailScreen(), arguments: [product.id, userToken])
-                  },
                   trailing: ClipRRect(
                     borderRadius: BorderRadius.circular(10),
                     child: Container(

--- a/bilrun/lib/screens/sign_in_up/phone_number/phone_number_certification.dart
+++ b/bilrun/lib/screens/sign_in_up/phone_number/phone_number_certification.dart
@@ -272,7 +272,7 @@ class _CertificationPhoneState extends State<CertificationPhone> {
                                                         Duration(seconds: 3),
                                                     backgroundColor:
                                                         Colors.white);
-                                                Get.off(
+                                                Get.offAll(
                                                   () => MainScreen(),
                                                   arguments:
                                                       PostCheckInNum.UserToken,

--- a/bilrun/lib/widgets/search/search_button.dart
+++ b/bilrun/lib/widgets/search/search_button.dart
@@ -10,9 +10,7 @@ class SearchButton extends StatelessWidget {
         iconSize: 25.0,
         color: Colors.black,
         onPressed: () {
-            Get.to(SearchbarScreen());
-
-
+          Get.to(() => SearchbarScreen());
         });
   }
 }


### PR DESCRIPTION
`빌려드림 상품 상세페이지 이동 -> 뒤로가기 ->빌림 페이지 이동 -> 빌려드림 페이지 이동(에러)`에서 오류가 나던 현상을 고쳤습니다.

원인은 유저 토큰을 라우트를 이용해서 Get.arguments로 받아오는데, 
바텀 네비게이션의 페이지를 그릴때마다 라우트에서 받아와서 오류가 일어났습니다.
뒤로가기를 하면 arguments 값으로 넘어오는 값이 없어서 오류가 난 것 같습니다 ^-^

그래서 유저 토큰을 바텀 네비게이션에 속한 각각의 메뉴에서 받아주는게 아니라,
메인페이지에서 받고, 각각의 페이지에서는 메인페이지의 토큰 값을 이용해주도록 하였습니다!